### PR TITLE
Fix status code error message

### DIFF
--- a/src/django_marina/test/test_cases.py
+++ b/src/django_marina/test/test_cases.py
@@ -51,7 +51,7 @@ class ExtendedTestCase(TestCase):
         self.assertEqual(
             response.status_code,
             status_code,
-            _msg_prefix_add(msg_prefix, "Invalid response code {response.status_code} (expected {status_code})."),
+            _msg_prefix_add(msg_prefix, f"Invalid response code {response.status_code} (expected {status_code})."),
         )
 
     def assertResponseOk(self, response):

--- a/tests/test_extended_test_case.py
+++ b/tests/test_extended_test_case.py
@@ -27,6 +27,11 @@ class ExtendedTestCaseTestCase(ExtendedTestCase):
         with self.assertRaises(AssertionError):
             self.assertResponseStatusCode(response, [200, 201])
 
+    def test_assert_response_status_code_message(self):
+        response = self.client.get(self.url_access_all)
+        with self.assertRaisesMessage(AssertionError, "Invalid response code 200 (expected 100)."):
+            self.assertResponseStatusCode(response, 100)
+
     def test_assert_response_ok(self):
         response = self.client.get(self.url_access_all)
         self.assertResponseOk(response)


### PR DESCRIPTION
The status code error message showed the format place holders for status codes instead of the actual status codes. This PR fixes that.

Before:
AssertionError: 403 != 200 : p_admin: Invalid response code {response.status_code} (expected {status_code}).

After:
AssertionError: 403 != 200 : p_admin: Invalid response code 403 (expected 200).