### PR TITLE
Use status codes from http module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## In development
+
+- Use Python's `http` module for status codes instead (#113).
+
 ## 21.1 (2021-11-18)
 
 - Switch to a CalVer YY.MINOR versioning scheme. MINOR is the number of the release in the given year. This is the first release in 2021 using this scheme, so its version is 21.1. The next version this year will be 21.2. The first version in 2022 will be 22.1.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ README = (HERE / "README.md").read_text()
 setup(
     name="django-marina",
     zip_safe=False,
-    version="21.1",
+    version="21.2",
     description="Django extensions by Zostera",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/src/django_marina/test/test_cases.py
+++ b/src/django_marina/test/test_cases.py
@@ -1,3 +1,5 @@
+from http import HTTPStatus
+
 from django.contrib.messages import get_messages
 from django.test import TestCase
 
@@ -20,11 +22,6 @@ def _msg_prefix_add(msg_prefix, value):
 
 class ExtendedTestCase(TestCase):
     """TestCase with a extended client and extra features for asserting response content."""
-
-    HTTP_REDIRECT = 302
-    HTTP_OK = 200
-    HTTP_FORBIDDEN = 403
-    HTTP_NOT_FOUND = 404
 
     client_class = ExtendedClient
 
@@ -56,24 +53,24 @@ class ExtendedTestCase(TestCase):
 
     def assertResponseOk(self, response):
         """
-        Assert that response has status HTTP_OK.
+        Assert that response has status code OK.
 
         :param response: HttpResponse
         """
-        self.assertResponseStatusCode(response, self.HTTP_OK)
+        self.assertResponseStatusCode(response, HTTPStatus.OK)
 
     def assertLoginRequired(self, path, **kwargs):
         """
-        Make request while not logged in, assert that response has status HTTP_FORBIDDEN or redirects to login page.
+        Make request while not logged in, assert that response has status code Forbidden or redirects to login page.
 
         :param path: Path for request
         :param kwargs: Kwargs for request
         """
         response = self._response(path, user=None, **kwargs)
-        if response.status_code == self.HTTP_REDIRECT:
+        if response.status_code == HTTPStatus.FOUND:
             self.assertRedirects(response, _login_url(path))
         else:
-            self.assertResponseStatusCode(response, self.HTTP_FORBIDDEN)
+            self.assertResponseStatusCode(response, HTTPStatus.FORBIDDEN)
 
     def _assertStatusCode(self, path, user, status_code, msg_prefix=None, **kwargs):
         """
@@ -90,16 +87,16 @@ class ExtendedTestCase(TestCase):
 
     def assertLoginNotRequired(self, path, **kwargs):
         """
-        Make request while not logged in, assert that response has status HTTP_OK.
+        Make request while not logged in, assert that response has status code OK.
 
         :param path: Path for request
         :param kwargs: Kwargs for request
         """
-        self._assertStatusCode(path, user=None, status_code=self.HTTP_OK, **kwargs)
+        self._assertStatusCode(path, user=None, status_code=HTTPStatus.OK, **kwargs)
 
     def assertAllowed(self, path, user, **kwargs):
         """
-        Make request, assert that response has status HTTP_OK.
+        Make request, assert that response has status code OK.
 
         If `user` contains a list of users, the assertion will be made for every user in that list.
 
@@ -107,11 +104,11 @@ class ExtendedTestCase(TestCase):
         :param user: User or list of users for request
         :param kwargs: Kwargs for request
         """
-        self._assertStatusCode(path, user=user, status_code=self.HTTP_OK, **kwargs)
+        self._assertStatusCode(path, user=user, status_code=HTTPStatus.OK, **kwargs)
 
     def assertForbidden(self, path, user, **kwargs):
         """
-        Make request, assert that response has status HTTP_FORBIDDEN.
+        Make request, assert that response has status code Forbidden.
 
         If `user` contains a list of users, the assertion will be made for every user in that list.
 
@@ -119,11 +116,11 @@ class ExtendedTestCase(TestCase):
         :param user: User or list of users for request
         :param kwargs: Kwargs for request
         """
-        self._assertStatusCode(path, user=user, status_code=self.HTTP_FORBIDDEN, **kwargs)
+        self._assertStatusCode(path, user=user, status_code=HTTPStatus.FORBIDDEN, **kwargs)
 
     def assertNotFound(self, path, user, **kwargs):
         """
-        Make request, assert that response has status HTTP_FORBIDDEN.
+        Make request, assert that response has status code Not Found.
 
         If `user` contains a list of users, the assertion will be made for every user in that list.
 
@@ -131,7 +128,7 @@ class ExtendedTestCase(TestCase):
         :param user: User or list of users for request
         :param kwargs: Kwargs for request
         """
-        self._assertStatusCode(path, user=user, status_code=self.HTTP_NOT_FOUND, **kwargs)
+        self._assertStatusCode(path, user=user, status_code=HTTPStatus.NOT_FOUND, **kwargs)
 
     def assertHasMessage(self, response, message):
         """

--- a/tests/test_extended_test_case.py
+++ b/tests/test_extended_test_case.py
@@ -88,8 +88,9 @@ class ExtendedTestCaseTestCase(ExtendedTestCase):
             self.assertForbidden(self.url_access_all, user=self.superuser)
 
         with self.assertRaises(AssertionError):
-            # Be careful with assertForbidden and user=None, if login is required you may get either
-            # HTTP_FORBIDDEN or HTTP_REDIRECT. In this test, we will get HTTP_REDIRECT.
+            # Be careful with assertForbidden and user=None.
+            # If login is required, the response returned may have a forbidden or redirect status code.
+            # In this test, we will get a redirect code.
             self.assertForbidden(self.url_access_authenticated, user=None)
         with self.assertRaises(AssertionError):
             self.assertForbidden(self.url_access_authenticated, user=self.user)


### PR DESCRIPTION
Fixes: #113 

This PR removes our own definition of HTTP status codes, and adopts the definition in Pythons' `http` module.

This also contains some fixes to docstrings.