### PR TITLE
Move version to source code, reduce dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Use ruff for linting and reformatting (#341).
 - Update Makefile and package configuration (#339, #340).
 - Drop support for Django 4.0 (EOL) (#352).
+- Move version to source code, reduce dependencies (#351).
 
 ## 23.2 (2023-04-22)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,23 +1,26 @@
+import importlib
 import os
-
-try:
-    from importlib.metadata import metadata
-except ImportError:
-    from importlib_metadata import metadata
-
-PROJECT_NAME = "django-marina"
+from configparser import ConfigParser
+from datetime import datetime
 
 on_rtd = os.environ.get("READTHEDOCS", None) == "True"
-project_metadata = metadata(PROJECT_NAME)
 
-project = project_metadata["name"]
-author = project_metadata["author"]
-copyright = f"2020, {author}"
+config_parser = ConfigParser()
+config_parser.read("../setup.cfg")
+metadata = config_parser["metadata"]
 
+project = metadata["name"]
+project_with_underscores = project.replace("-", "_")
+
+module = importlib.import_module(f"{project_with_underscores}")
 # The full version, including alpha/beta/rc tags, in x.y.z.misc format
-release = project_metadata["version"]
+release = module.__version__
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])
+
+author = metadata["author"]
+year = datetime.now().year
+copyright = f"{year}, {author}"
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -25,7 +28,7 @@ extensions = [
     "sphinx_mdinclude",
 ]
 pygments_style = "sphinx"
-htmlhelp_basename = f"{PROJECT_NAME}-doc"
+htmlhelp_basename = f"{project}-doc"
 
 if not on_rtd:  # only import and set the theme if we're building docs locally
     import sphinx_rtd_theme

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-marina
-version = 23.2
+version = attr: django_marina.__version__
 description = Django extensions by Zostera
 long_description = file:README.md
 long_description_content_type = text/markdown
@@ -38,7 +38,6 @@ python_requires = >=3.7
 install_requires =
     Django>=3.2
     beautifulsoup4>=4.8.0
-    importlib-metadata; python_version<"3.8"
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 name = django-marina
 version = attr: django_marina.__version__
 description = Django extensions by Zostera
-long_description = file:README.md
+long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/zostera/django-marina
 author = Dylan Verheul

--- a/src/django_marina/__init__.py
+++ b/src/django_marina/__init__.py
@@ -2,12 +2,4 @@ __all__ = [
     "__version__",
 ]
 
-PACKAGE_NAME = "django-marina"
-
-try:
-    from importlib.metadata import metadata
-except ImportError:
-    from importlib_metadata import metadata
-
-package_metadata = metadata(PACKAGE_NAME)
-__version__ = package_metadata["Version"]
+__version__ = "23.2"

--- a/src/django_marina/__init__.py
+++ b/src/django_marina/__init__.py
@@ -2,4 +2,4 @@ __all__ = [
     "__version__",
 ]
 
-__version__ = "23.2"
+__version__ = "23.2dev"


### PR DESCRIPTION
This moves the version back to a central place in the source code, see:
https://packaging.python.org/en/latest/guides/single-sourcing-package-version/#

This also makes the `docs/conf.py` uniform for all our open source packages, reading the package name from `setup.cfg` and the version from the actual package.