### PR TITLE
Several small improvements

### DIFF
--- a/src/django_marina/db/models.py
+++ b/src/django_marina/db/models.py
@@ -42,7 +42,7 @@ class ProtectedModelMixin:
         return self.delete_protection_message
 
     def delete(self, *args, **kwargs):
-        """Delete the instance, unlessit has delete protection."""
+        """Delete the instance, unless it has delete protection."""
         if self.has_delete_protection:
             raise PermissionDenied(self.get_delete_protection_message())
         return super().delete(*args, **kwargs)

--- a/src/django_marina/test/clients.py
+++ b/src/django_marina/test/clients.py
@@ -13,7 +13,7 @@ def _get_soup(response):
 class ExtendedClient(Client):
     """Client with added features."""
 
-    USER_IGNORE = -1
+    USER_IGNORE = object()
 
     def request(self, **request):
         """Request a response from the server."""
@@ -30,7 +30,7 @@ class ExtendedClient(Client):
         When `user` is `None`, this will force a logout.
         In all other cases, `user` will be logged in.
         """
-        if user != self.USER_IGNORE:
+        if user is not self.USER_IGNORE:
             if user is None:
                 self.logout()
             else:

--- a/src/django_marina/test/runners.py
+++ b/src/django_marina/test/runners.py
@@ -15,8 +15,8 @@ class TempMediaMixin:
     def setup_test_environment(self):
         """Create temp directory and update MEDIA_ROOT and default storage."""
         super().setup_test_environment()
-        settings._original_media_root = settings.MEDIA_ROOT
-        settings._original_file_storage = settings.DEFAULT_FILE_STORAGE
+        self._original_media_root = settings.MEDIA_ROOT
+        self._original_file_storage = settings.DEFAULT_FILE_STORAGE
         self._temp_media = tempfile.mkdtemp()
         settings.MEDIA_ROOT = self._temp_media
         settings.DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
@@ -25,10 +25,8 @@ class TempMediaMixin:
         """Delete temp storage."""
         super().teardown_test_environment()
         shutil.rmtree(self._temp_media, ignore_errors=True)
-        settings.MEDIA_ROOT = settings._original_media_root
-        del settings._original_media_root
-        settings.DEFAULT_FILE_STORAGE = settings._original_file_storage
-        del settings._original_file_storage
+        settings.MEDIA_ROOT = self._original_media_root
+        settings.DEFAULT_FILE_STORAGE = self._original_file_storage
 
 
 class TempMediaDiscoverRunner(TempMediaMixin, DiscoverRunner):

--- a/src/django_marina/test/test_cases.py
+++ b/src/django_marina/test/test_cases.py
@@ -31,12 +31,10 @@ class ExtendedTestCase(TestCase):
         """Return response on a separate client instance, so without any side effects."""
         client = self.client_class()
         method = kwargs.pop("method", "get").lower()
-        if method == "get":
-            response = client.get(path, user=user, **kwargs)
-        elif method == "post":
-            response = client.post(path, user=user, **kwargs)
+        if method in ("get", "post", "put", "patch", "delete"):
+            response = getattr(client, method)(path, user=user, **kwargs)
         else:
-            raise AssertionError(f"Invalid method {method} (expected GET or POST).")
+            raise AssertionError(f"Invalid method {method} (expected GET, POST, PUT, PATCH or DELETE).")
         return response
 
     def assertResponseStatusCode(self, response, status_code, msg_prefix=None):

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -6,3 +6,21 @@ from django_marina.html import remove_attrs
 class HtmlTestCase(TestCase):
     def test_remove_attrs(self):
         self.assertEqual(remove_attrs('<span foo="bar"></span>', ["foo"]), "<span></span>")
+
+    def test_remove_attrs_none_html(self):
+        self.assertIsNone(remove_attrs(None, ["foo"]))
+
+    def test_remove_attrs_empty_string(self):
+        self.assertEqual(remove_attrs("", ["foo"]), "")
+
+    def test_remove_attrs_none_attrs(self):
+        self.assertEqual(remove_attrs('<span foo="bar"></span>', None), '<span foo="bar"></span>')
+
+    def test_remove_attrs_empty_attrs(self):
+        self.assertEqual(remove_attrs('<span foo="bar"></span>', []), '<span foo="bar"></span>')
+
+    def test_remove_attrs_multiple(self):
+        self.assertEqual(remove_attrs('<span foo="1" bar="2"></span>', ["foo", "bar"]), "<span></span>")
+
+    def test_remove_attrs_nonexistent(self):
+        self.assertEqual(remove_attrs('<span foo="bar"></span>', ["baz"]), '<span foo="bar"></span>')

--- a/tests/test_temp_media_runner.py
+++ b/tests/test_temp_media_runner.py
@@ -33,14 +33,12 @@ class TempMediaDiscoverRunnerTestCase(SimpleTestCase):
                 settings.DEFAULT_FILE_STORAGE,
                 "django.core.files.storage.FileSystemStorage",
             )
-            self.assertTrue(hasattr(settings, "_original_media_root"))
-            self.assertTrue(hasattr(settings, "_original_file_storage"))
+            self.assertEqual(runner._original_media_root, original_media_root)
+            self.assertEqual(runner._original_file_storage, original_storage)
         finally:
             temp_media_root = runner._temp_media
             runner.teardown_test_environment()
 
         self.assertEqual(settings.MEDIA_ROOT, original_media_root)
         self.assertEqual(settings.DEFAULT_FILE_STORAGE, original_storage)
-        self.assertFalse(hasattr(settings, "_original_media_root"))
-        self.assertFalse(hasattr(settings, "_original_file_storage"))
         self.assertFalse(os.path.exists(temp_media_root))


### PR DESCRIPTION
## Summary

- **`runners.py`**: store original media settings on `self` instead of `settings` object — avoids relying on Django private `_original_*` attributes that could disappear in any release
- **`clients.py`**: replace `USER_IGNORE = -1` magic number with `object()` sentinel and use identity check (`is not`) instead of equality — eliminates false match if a user object ever equals `-1`
- **`test_cases.py`**: support PUT, PATCH, DELETE in `_response()` alongside GET and POST
- **`tests/test_html.py`**: add 6 missing cases for `remove_attrs` (None html, empty string, None attrs, empty attrs list, multiple attrs, nonexistent attr)
- **`db/models.py`**: fix docstring typo ("unlessit" → "unless it")

## Test plan

- [x] `just lint` passes
- [x] `just test` passes — 41 tests (was 35, +6 new html tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)