### PR TITLE
Replace DEFAULT_FILE_STORAGE with STORAGES for Django 6.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Replace `USER_IGNORE = -1` magic sentinel with `object()` in `ExtendedClient` (#652).
 - Support PUT, PATCH and DELETE in `ExtendedTestCase._response()` (#652).
 - Expand test coverage for `remove_attrs` (#652).
+- Replace deprecated `DEFAULT_FILE_STORAGE` with `STORAGES` for Django 6.0 compatibility (#653).
 
 ## 26.1 (2026-01-02)
 

--- a/src/django_marina/html.py
+++ b/src/django_marina/html.py
@@ -2,7 +2,7 @@ from bs4 import BeautifulSoup
 
 
 def remove_attrs(html, attrs=None):
-    """Return html string without the specified tags."""
+    """Return html string without the specified attributes."""
     if html and attrs:
         soup = BeautifulSoup(html, "html.parser")
         soup = _remove_attrs(soup, attrs)

--- a/src/django_marina/test/runners.py
+++ b/src/django_marina/test/runners.py
@@ -16,17 +16,20 @@ class TempMediaMixin:
         """Create temp directory and update MEDIA_ROOT and default storage."""
         super().setup_test_environment()
         self._original_media_root = settings.MEDIA_ROOT
-        self._original_file_storage = settings.DEFAULT_FILE_STORAGE
+        self._original_storages = settings.STORAGES.copy()
         self._temp_media = tempfile.mkdtemp()
         settings.MEDIA_ROOT = self._temp_media
-        settings.DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+        settings.STORAGES = {
+            **settings.STORAGES,
+            "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+        }
 
     def teardown_test_environment(self):
         """Delete temp storage."""
         super().teardown_test_environment()
         shutil.rmtree(self._temp_media, ignore_errors=True)
         settings.MEDIA_ROOT = self._original_media_root
-        settings.DEFAULT_FILE_STORAGE = self._original_file_storage
+        settings.STORAGES = self._original_storages
 
 
 class TempMediaDiscoverRunner(TempMediaMixin, DiscoverRunner):

--- a/tests/test_temp_media_runner.py
+++ b/tests/test_temp_media_runner.py
@@ -1,7 +1,7 @@
 import os
 
 from django.conf import settings
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
 from django_marina.test.runners import TempMediaMixin
 
@@ -19,26 +19,25 @@ class _TempMediaRunner(TempMediaMixin, _NoopRunner):
 
 
 class TempMediaDiscoverRunnerTestCase(SimpleTestCase):
-    @override_settings(DEFAULT_FILE_STORAGE="django.core.files.storage.FileSystemStorage")
     def test_temp_media_setup_and_teardown(self):
         runner = _TempMediaRunner()
         original_media_root = settings.MEDIA_ROOT
-        original_storage = settings.DEFAULT_FILE_STORAGE
+        original_storages = settings.STORAGES.copy()
 
         runner.setup_test_environment()
         try:
             self.assertTrue(os.path.isdir(settings.MEDIA_ROOT))
             self.assertNotEqual(settings.MEDIA_ROOT, original_media_root)
             self.assertEqual(
-                settings.DEFAULT_FILE_STORAGE,
+                settings.STORAGES["default"]["BACKEND"],
                 "django.core.files.storage.FileSystemStorage",
             )
             self.assertEqual(runner._original_media_root, original_media_root)
-            self.assertEqual(runner._original_file_storage, original_storage)
+            self.assertEqual(runner._original_storages, original_storages)
         finally:
             temp_media_root = runner._temp_media
             runner.teardown_test_environment()
 
         self.assertEqual(settings.MEDIA_ROOT, original_media_root)
-        self.assertEqual(settings.DEFAULT_FILE_STORAGE, original_storage)
+        self.assertEqual(settings.STORAGES, original_storages)
         self.assertFalse(os.path.exists(temp_media_root))


### PR DESCRIPTION
## Summary

- **`runners.py`**: replace `DEFAULT_FILE_STORAGE` with `STORAGES["default"]` — `DEFAULT_FILE_STORAGE` was removed in Django 6.0; `STORAGES` was introduced in Django 4.2 and covers the full supported matrix (4.2, 5.2, 6.0, main)
- **`html.py`**: fix docstring — "tags" → "attributes"

## Test plan

- [x] `just lint` passes
- [x] `just test` passes (41 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)