### PR TITLE
Remove duplicated Python x Django matrix table in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,15 +88,6 @@ tests/
     test_version.py
 ```
 
-Test matrix (tox) — not a full grid:
-
-| Python  | Django versions         |
-|---------|-------------------------|
-| 3.10    | 5.2                     |
-| 3.11    | 5.2                     |
-| 3.12    | 5.2, 6.0, 6.1, main     |
-| 3.13    | 5.2, 6.0, 6.1, main     |
-| 3.14    | 5.2, 6.0, 6.1, main     |
 The current Python × Django matrix is not a full grid — see `tox.ini`'s `envlist` for what's actually tested (`pyproject.toml` classifiers and `ci.yml`'s matrix must match it). Don't copy the matrix into prose elsewhere; it drifts. See [MAINTAINING.md](MAINTAINING.md) for the policy behind how the matrix is chosen and kept current.
 
 Target the matrix when adding features; avoid Django-version-specific code paths where possible.


### PR DESCRIPTION
## Summary
#657 (matrix update) and #658 (docs, replacing the table with a pointer to `tox.ini`/`MAINTAINING.md`) landed close together without one being rebased onto the other — GitHub's merge combined both edits additively instead of as a clean replacement, so `main` currently has both the stale table *and* the pointer sentence back to back.

Removed the leftover table + its "Test matrix (tox) — not a full grid:" heading, keeping only the pointer sentence (which already says the same thing without a number that can go stale).

## Test plan
- [x] `just lint` — all checks passed
- [x] `just docs` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)