### PR TITLE
Ignore pyproject.toml.orig in check-manifest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,4 +123,4 @@ source-include = [
 ]
 
 [tool.check-manifest]
-ignore = ["uv.lock"]
+ignore = ["uv.lock", "pyproject.toml.orig"]


### PR DESCRIPTION
## Summary
- `uv_build` bumped past 0.12.0 in #661, which now writes a `pyproject.toml.orig` backup into the sdist
- `check-manifest` flags that file as untracked, failing the `build` CI job (see #661's failed build check)
- Same root cause and fix as zostera/django-bootstrap3

## Test plan
- [x] `uv build` + `uvx check-manifest` pass locally