### PR TITLE
Fix release process doc: version bump via PR, not direct push to main

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -25,9 +25,12 @@ copy always drifts out of sync with the files that actually enforce it.
 
 ## Release process
 
-1. Update `CHANGELOG.md` and bump `version` in `pyproject.toml`
-2. Commit and push to `main`
+1. On a release branch, update `CHANGELOG.md` and bump `version` in `pyproject.toml`; open a PR and merge it
+2. Check out and pull `main`
 3. `just build` — builds wheel + tarball, runs packaging checks, and smoke-tests both against an isolated env
 4. `just release-tag` — creates and pushes the version tag; GitHub Actions publishes to PyPI
+
+`main` is protected — direct pushes are rejected (or bypass branch protection, which is worse). Always land the
+version bump through a PR like any other change.
 
 `just release-tag` requires a clean working directory and the current branch to be `main`. It will fail otherwise.

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -37,6 +37,11 @@ as a PR in that sibling's own repo — never push straight to `main`.
 process) everywhere; substitute package name and any package-specific pinned-dependency
 notes (e.g. a Bootstrap CDN version).
 
+The release process's step 1 (version bump) must go through a release branch + PR, not a
+direct commit to `main` — `main` is protected in every one of these repos, so "commit and
+push to main" either fails or requires bypassing branch protection. Only `just release-tag`
+(step 4) pushes directly, and that's a tag, not a commit to `main`.
+
 ## Naming convention (intentional split, not drift)
 
 - **Legacy** (django-bootstrap3, django-bootstrap4): import name has no `django_` prefix —


### PR DESCRIPTION
## Summary
- MAINTAINING.md's release process said "commit and push to main" for the version-bump step
- `main` is protected here too (PR required, status checks enforced) — same bug just found and fixed in zostera/django-bootstrap3#1135
- Fixes the doc, and documents the correction in PACKAGING.md so it carries over to django-bootstrap4/5 and django-icons

## Test plan
- [x] Docs-only change