### PR TITLE
Auto-create GitHub Release with changelog notes on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       name: pypi
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Checkout
@@ -74,3 +74,23 @@ jobs:
         # Only publish on tag push; manual runs act as a dry run
         if: github.event_name == 'push'
         run: uv publish
+
+      - name: Extract changelog section
+        if: github.event_name == 'push'
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v ver="$VERSION" '
+            /^## / {
+              if (found) exit
+              if ($0 == "## " ver || $0 ~ "^## " ver " ") found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" dist/* --title "$GITHUB_REF_NAME" --notes-file release-notes.md


### PR DESCRIPTION
## Summary
- Tag pushes already build, check, and publish to PyPI via `uv publish` — but no GitHub Release object gets created, so the Releases tab shows only bare tags with no changelog visible.
- Adds two steps after `Publish` (both `if: github.event_name == 'push'`, so skipped on `workflow_dispatch` dry runs, and skipped automatically if `Publish` fails since GH Actions stops the job on step failure): extract the matching `## X.Y` section from `CHANGELOG.md`, then `gh release create` with that as the notes body and the built `dist/*` artifacts attached.
- Bumped job permissions from `contents: read` to `contents: write` (required for `gh release create`).

## Test plan
- [ ] Verified `awk` changelog extraction locally against `26.1` section — correct output
- [ ] Merge, then next real tag push (`v` bump) confirms a Release is created with correct notes + attached dist files